### PR TITLE
fix(models): resolve dataclass and SQLAlchemy test collection errors

### DIFF
--- a/src/alpha_pulse/agents/interfaces.py
+++ b/src/alpha_pulse/agents/interfaces.py
@@ -27,8 +27,8 @@ class MarketData:
     fundamentals: Optional[Dict[str, Any]] = None  # Fundamental data if available
     sentiment: Optional[Dict[str, float]] = None  # Sentiment scores if available
     technical_indicators: Optional[Dict[str, pd.DataFrame]] = None  # Technical indicators
-    timestamp: datetime = field(default_factory=datetime.now)
     data_by_symbol: Optional[Dict[str, List[Any]]] = None  # Raw data by symbol
+    timestamp: datetime = field(default_factory=datetime.now)
 
 
 @dataclass

--- a/src/alpha_pulse/agents/supervisor/interfaces.py
+++ b/src/alpha_pulse/agents/supervisor/interfaces.py
@@ -26,10 +26,10 @@ class AgentHealth:
     state: AgentState
     last_active: datetime
     error_count: int
-    last_error: Optional[str]
     memory_usage: float  # in MB
     cpu_usage: float    # percentage
     metrics: Dict[str, float]
+    last_error: Optional[str] = None
     timestamp: datetime = field(default_factory=datetime.now)
 
 
@@ -41,11 +41,11 @@ class Task:
     task_type: str
     priority: int
     parameters: Dict[str, Any]
-    created_at: datetime = field(default_factory=datetime.now)
     completed_at: Optional[datetime] = None
     status: str = "pending"
     result: Optional[Dict[str, Any]] = None
     error: Optional[str] = None
+    created_at: datetime = field(default_factory=datetime.now)
 
 
 class ISelfSupervisedAgent(ITradeAgent):

--- a/src/alpha_pulse/execution/smart_order_router.py
+++ b/src/alpha_pulse/execution/smart_order_router.py
@@ -84,12 +84,12 @@ class SmartOrder:
     config: SmartOrderConfig
     target_price: Optional[float] = None
     stop_price: Optional[float] = None
-    created_at: datetime = field(default_factory=datetime.now)
     status: OrderStatus = OrderStatus.PENDING
     filled_quantity: float = 0.0
     avg_filled_price: Optional[float] = None
     slices: List[OrderSlice] = field(default_factory=list)
     execution_stats: Dict[str, Any] = field(default_factory=dict)
+    created_at: datetime = field(default_factory=datetime.now)
 
 
 class MarketDataAnalyzer:

--- a/src/alpha_pulse/models/ensemble_model.py
+++ b/src/alpha_pulse/models/ensemble_model.py
@@ -57,7 +57,7 @@ class AgentSignalRecord(Base):
     timestamp = Column(DateTime, nullable=False)
     signal = Column(Float, nullable=False)  # -1 to 1
     confidence = Column(Float, nullable=False)  # 0 to 1
-    metadata = Column(JSON)
+    meta_data = Column(JSON)
     market_conditions = Column(JSON)
     
     # Relationships
@@ -76,7 +76,7 @@ class EnsemblePrediction(Base):
     confidence = Column(Float, nullable=False)
     contributing_agents = Column(JSON)  # List of agent IDs
     weights = Column(JSON)  # Dict of agent_id: weight
-    metadata = Column(JSON)
+    meta_data = Column(JSON)
     execution_time_ms = Column(Float)
     
     # Relationships

--- a/src/alpha_pulse/models/trading_data.py
+++ b/src/alpha_pulse/models/trading_data.py
@@ -151,7 +151,7 @@ class Position(Base):
     status = Column(String(20), default="open", nullable=False)
     
     # Encrypted metadata
-    metadata = Column(
+    meta_data = Column(
         EncryptedJSON(encryption_context="position_metadata"),
         nullable=True
     )


### PR DESCRIPTION
## Summary
- Fixed dataclass field ordering errors where non-default arguments followed default arguments
- Renamed SQLAlchemy model columns from 'metadata' to 'meta_data' to avoid conflicts with SQLAlchemy 2.0's reserved attribute

## Changes
- **agents/interfaces.py**: Fixed MarketData dataclass field ordering
- **execution/smart_order_router.py**: Fixed SmartOrder dataclass field ordering  
- **agents/supervisor/interfaces.py**: Fixed AgentHealth and Task dataclass field ordering
- **models/ensemble_model.py**: Renamed 'metadata' columns to 'meta_data'
- **models/trading_data.py**: Renamed 'metadata' column to 'meta_data'

## Test plan
- [x] All linting passes
- [ ] Test collection errors should be reduced
- [ ] CI/CD pipeline should progress further in test discovery

🤖 Generated with [Claude Code](https://claude.ai/code)